### PR TITLE
feat: add full room state handler

### DIFF
--- a/android/app/src/main/java/com/example/dicerealmandroid/DicerealmClient.java
+++ b/android/app/src/main/java/com/example/dicerealmandroid/DicerealmClient.java
@@ -1,0 +1,91 @@
+package com.example.dicerealmandroid;
+
+import android.util.Log;
+
+import com.example.dicerealmandroid.command.Command;
+import com.example.dicerealmandroid.command.FullRoomStateCommand;
+import com.example.dicerealmandroid.core.RoomState;
+import com.google.gson.Gson;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import dev.gustavoavila.websocketclient.WebSocketClient;
+
+public class DicerealmClient extends WebSocketClient {
+    private Gson gson = new Gson();
+
+    private RoomState roomState = new RoomState();
+
+    private final static String baseUrl = "wss://better-tonye-dicerealm-f2e6ebbb.koyeb.app/room/";
+
+    @Override
+    public void onOpen() {
+        System.out.println("onOpen");
+    }
+
+    @Override
+    public void onTextReceived(String message) {
+        Log.d("info", "message received + " + message);
+        Command command = gson.fromJson(message, Command.class);
+        System.out.println("Command is of type: " + command.getType());
+        switch (command.getType()) {
+            case "FULL_ROOM_STATE":
+                roomState = gson.fromJson(message, FullRoomStateCommand.class).getRoomState();
+                break;
+            case "PLAYER_JOIN":
+                // TODO
+                break;
+            case "PLAYER_LEAVE":
+                // TODO
+                break;
+            case "UPDATE_PLAYER_DETAILS":
+                // TODO
+                break;
+            default:
+                System.out.println("Command Not Handled: " + command.getType());
+        }
+    }
+
+    @Override
+    public void onBinaryReceived(byte[] data) {
+        System.out.println("onBinaryReceived");
+    }
+
+    @Override
+    public void onPingReceived(byte[] data) {
+        System.out.println("onPingReceived");
+    }
+
+    @Override
+    public void onPongReceived(byte[] data) {
+        System.out.println("onPongReceived");
+    }
+
+    @Override
+    public void onException(Exception e) {
+        System.out.println(e.getMessage());
+    }
+
+    @Override
+    public void onCloseReceived(int reason, String description) {
+        System.out.println("onCloseReceived");
+    }
+
+    public void connectToRoom(String roomCode) {
+        this.setConnectTimeout(10000);
+        this.setReadTimeout(60000);
+        this.addHeader("Origin", "http://developer.example.com");
+        this.enableAutomaticReconnection(5000);
+        this.connect();
+    }
+
+    public DicerealmClient (String roomCode) throws URISyntaxException {
+        super(new URI(DicerealmClient.baseUrl + roomCode));
+        this.setConnectTimeout(10000);
+        this.setReadTimeout(60000);
+        this.addHeader("Origin", "http://developer.example.com");
+        this.enableAutomaticReconnection(5000);
+        this.connect();
+    }
+}

--- a/android/app/src/main/java/com/example/dicerealmandroid/MainActivity.java
+++ b/android/app/src/main/java/com/example/dicerealmandroid/MainActivity.java
@@ -9,73 +9,8 @@ import androidx.core.graphics.Insets;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-
-import dev.gustavoavila.websocketclient.WebSocketClient;
-import com.google.gson.Gson;
-
 public class MainActivity extends AppCompatActivity {
-    private Gson gson = new Gson();
-    private WebSocketClient webSocketClient;
-
-    private void createWebSocketClient() {
-        URI uri;
-        try {
-            // replace this with your dev device's IP address (not localhost, as localhost will point to the emulator)
-            uri = new URI("wss://better-tonye-dicerealm-f2e6ebbb.koyeb.app/room/test");
-            // uri = new URI("ws://192.168.18.69:8080/room/test");
-        }
-        catch (URISyntaxException e) {
-            e.printStackTrace();
-            return;
-        }
-
-        webSocketClient = new WebSocketClient(uri) {
-            @Override
-            public void onOpen() {
-                System.out.println("onOpen");
-            }
-
-            @Override
-            public void onTextReceived(String message) {
-                System.out.println("onTextReceived: " + message);
-                Command command = gson.fromJson(message, Command.class);
-                System.out.println("Command is of type: " + command.getType());
-            }
-
-            @Override
-            public void onBinaryReceived(byte[] data) {
-                System.out.println("onBinaryReceived");
-            }
-
-            @Override
-            public void onPingReceived(byte[] data) {
-                System.out.println("onPingReceived");
-            }
-
-            @Override
-            public void onPongReceived(byte[] data) {
-                System.out.println("onPongReceived");
-            }
-
-            @Override
-            public void onException(Exception e) {
-                System.out.println(e.getMessage());
-            }
-
-            @Override
-            public void onCloseReceived(int reason, String description) {
-                System.out.println("onCloseReceived");
-            }
-        };
-
-        webSocketClient.setConnectTimeout(10000);
-        webSocketClient.setReadTimeout(60000);
-        webSocketClient.addHeader("Origin", "http://developer.example.com");
-        webSocketClient.enableAutomaticReconnection(5000);
-        webSocketClient.connect();
-    }
+    private DicerealmClient dicerealmClient;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -89,7 +24,10 @@ public class MainActivity extends AppCompatActivity {
         });
 
         Log.d("info", "Hello!");
-
-        createWebSocketClient();
+        try {
+            dicerealmClient = new DicerealmClient("test");
+        } catch (Exception e) {
+            Log.e("error", "Could not connect to room", e);
+        }
     }
 }

--- a/android/app/src/main/java/com/example/dicerealmandroid/command/Command.java
+++ b/android/app/src/main/java/com/example/dicerealmandroid/command/Command.java
@@ -1,4 +1,4 @@
-package com.example.dicerealmandroid;
+package com.example.dicerealmandroid.command;
 
 public class Command {
     private final String type;

--- a/android/app/src/main/java/com/example/dicerealmandroid/command/FullRoomStateCommand.java
+++ b/android/app/src/main/java/com/example/dicerealmandroid/command/FullRoomStateCommand.java
@@ -1,0 +1,19 @@
+package com.example.dicerealmandroid.command;
+
+import com.example.dicerealmandroid.core.RoomState;
+
+public class FullRoomStateCommand extends Command {
+    private RoomState state;
+    private String myId;
+    public FullRoomStateCommand() {
+        super("FULL_ROOM_STATE");
+    }
+
+    public RoomState getRoomState() {
+        return state;
+    }
+
+    public String getMyId() {
+        return myId;
+    }
+}

--- a/android/app/src/main/java/com/example/dicerealmandroid/core/Entity.java
+++ b/android/app/src/main/java/com/example/dicerealmandroid/core/Entity.java
@@ -1,0 +1,175 @@
+package com.example.dicerealmandroid.core;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class Entity {
+    public enum Race {
+        HUMAN,
+        ELF,
+        DEMON,
+        DWARF,
+        TIEFLING
+    }
+
+    public enum EntityClass {
+        WARRIOR,
+        WIZARD,
+        CLERIC,
+        ROGUE,
+        RANGER
+    }
+
+    public enum Stat {
+        MAX_HEALTH,
+        ARMOUR_CLASS,
+        STRENGTH,
+        DEXTERITY,
+        CONSTITUTION,
+        INTELLIGENCE,
+        WISDOM,
+        CHARISMA
+    }
+
+    public interface Stats {
+        public abstract int getStat(Stat stat);
+    }
+
+
+    public static class StatsMap extends HashMap<Stat, Integer> implements Stats {
+        @Override
+        public int getStat(Stat stat) {
+            return super.get(stat);
+        }
+
+        public StatsMap() {
+            super();
+        }
+
+        public StatsMap(Map<Stat, Integer> stats) {
+            super.putAll(stats);
+        }
+    }
+
+    public static class ClassStats {
+        private static final Map<EntityClass, StatsMap> classStatsMap = new HashMap<>();
+
+        static {
+            // Warrior starting stats
+            classStatsMap.put(EntityClass.WARRIOR, new StatsMap(Map.of(
+                    Stat.MAX_HEALTH, 24,
+                    Stat.ARMOUR_CLASS, 15,
+                    Stat.STRENGTH, 16,
+                    Stat.DEXTERITY, 12,
+                    Stat.CONSTITUTION, 16,
+                    Stat.INTELLIGENCE, 8,
+                    Stat.WISDOM, 10,
+                    Stat.CHARISMA, 10
+            )));
+
+            // Wizard starting stats
+            classStatsMap.put(EntityClass.WIZARD, new StatsMap(Map.of(
+                    Stat.MAX_HEALTH, 18,
+                    Stat.ARMOUR_CLASS, 12,
+                    Stat.STRENGTH, 8,
+                    Stat.DEXTERITY, 12,
+                    Stat.CONSTITUTION, 10,
+                    Stat.INTELLIGENCE, 18,
+                    Stat.WISDOM, 12,
+                    Stat.CHARISMA, 10
+            )));
+
+            // CLERIC starting stats
+            classStatsMap.put(EntityClass.CLERIC, new StatsMap(Map.of(
+                    Stat.MAX_HEALTH, 18,
+                    Stat.ARMOUR_CLASS, 12,
+                    Stat.STRENGTH, 8,
+                    Stat.DEXTERITY, 12,
+                    Stat.CONSTITUTION, 12,
+                    Stat.INTELLIGENCE, 13,
+                    Stat.WISDOM, 16,
+                    Stat.CHARISMA, 14
+            )));
+
+            // Rogue starting stats
+            classStatsMap.put(EntityClass.ROGUE, new StatsMap(Map.of(
+                    Stat.MAX_HEALTH, 18,
+                    Stat.ARMOUR_CLASS, 14,
+                    Stat.STRENGTH, 12,
+                    Stat.DEXTERITY, 15,
+                    Stat.CONSTITUTION, 14,
+                    Stat.INTELLIGENCE, 10,
+                    Stat.WISDOM, 10,
+                    Stat.CHARISMA, 16
+            )));
+
+            // Ranger starting stats
+            classStatsMap.put(EntityClass.RANGER, new StatsMap(Map.of(
+                    Stat.MAX_HEALTH, 20,
+                    Stat.ARMOUR_CLASS, 14,
+                    Stat.STRENGTH, 12,
+                    Stat.DEXTERITY, 18,
+                    Stat.CONSTITUTION, 14,
+                    Stat.INTELLIGENCE, 10,
+                    Stat.WISDOM, 10,
+                    Stat.CHARISMA, 12
+            )));
+
+
+        }
+
+        // Return the starting stats for the given EntityClass
+        public static StatsMap getStatsForClass(EntityClass entityClass) {
+            return classStatsMap.getOrDefault(entityClass, new StatsMap()); // Return empty if not found
+        }
+    }
+
+
+
+    private UUID id;
+    private String displayName;
+    private Race race;
+    private EntityClass entityClass;
+    private int health;
+    private StatsMap baseStats;
+    private StatsMap stats;
+
+    public Entity(String displayName, Race race, EntityClass entityClass, StatsMap baseStats) {
+        this.id = UUID.randomUUID();
+        this.displayName = displayName;
+        this.race = race;
+        this.entityClass = entityClass;
+
+        //Get base stats from ClassStats class
+        this.baseStats = ClassStats.getStatsForClass(entityClass);
+        this.health = baseStats.get(Stat.MAX_HEALTH);
+
+        // Initialize the stats map by copying baseStats initially
+        this.stats = new StatsMap(baseStats);
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public Race getRace() {
+        return race;
+    }
+
+    public EntityClass getEntityClass() {
+        return entityClass;
+    }
+
+    public int getHealth() {
+        return health;
+    }
+
+    public boolean isAlive() {
+        return health > 0;
+    }
+}

--- a/android/app/src/main/java/com/example/dicerealmandroid/core/Player.java
+++ b/android/app/src/main/java/com/example/dicerealmandroid/core/Player.java
@@ -1,0 +1,12 @@
+package com.example.dicerealmandroid.core;
+
+/**
+ * Represents a player in the game
+ * @see Entity
+ */
+public class Player extends Entity {
+
+    public Player(String name, Entity.Race race, Entity.EntityClass entityClass, Entity.StatsMap baseStats) {
+        super(name, race, entityClass, baseStats);
+    }
+}

--- a/android/app/src/main/java/com/example/dicerealmandroid/core/RoomState.java
+++ b/android/app/src/main/java/com/example/dicerealmandroid/core/RoomState.java
@@ -1,0 +1,29 @@
+package com.example.dicerealmandroid.core;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class RoomState {
+    public enum State {
+        LOBBY, DIALOGUE_TURN, DIALOGUE_PROCESSING, BATTLE
+    }
+    private State state = State.LOBBY;
+    private Map<UUID, Player> playerMap = new HashMap<>();
+
+    public State getState() {
+        return state;
+    }
+
+    public void setState(State state) {
+        this.state = state;
+    }
+
+    public Player[] getPlayers() {
+        return playerMap.values().toArray(new Player[playerMap.size()]);
+    }
+
+    public Map<UUID, Player> getPlayerMap() {
+        return playerMap;
+    }
+}


### PR DESCRIPTION
- Add `DicerealmClient` which acts as a monolithic handler for the room state, including handling of incoming commands.

- Add partial replicas of core classes such as `Player`, `Entity` and `Room` etc.

### Testing

1. In `DicerealmClient` add a breakpoint on line 35:
![image](https://github.com/user-attachments/assets/8e3ccac0-e6ea-462a-aa30-3059dce38c82)

2. Run in debug mode

