### PR TITLE
fix: dialog disabling and game initialization logic 

### DIFF
--- a/android/app/src/main/java/com/example/dicerealmandroid/DicerealmClient.java
+++ b/android/app/src/main/java/com/example/dicerealmandroid/DicerealmClient.java
@@ -9,6 +9,7 @@ import com.dicerealm.core.command.PlayerJoinCommand;
 import com.dicerealm.core.command.ShowPlayerActionsCommand;
 import com.dicerealm.core.command.UpdatePlayerDetailsCommand;
 import com.dicerealm.core.command.dialogue.DialogueTurnActionCommand;
+import com.dicerealm.core.command.dialogue.EndTurnCommand;
 import com.dicerealm.core.command.dialogue.StartTurnCommand;
 import com.dicerealm.core.player.Player;
 import com.dicerealm.core.command.PlayerLeaveCommand;
@@ -83,18 +84,24 @@ public class DicerealmClient extends WebSocketClient {
                     break;
 
                 case "START_GAME":
-                    Message.showMessage("Game started.");
-                    gameRepo.gameStarted();
+                    Message.showMessage("Initializing your game, please wait");
+                    gameRepo.serverNotFree();
                     break;
 
                 case "DIALOGUE_START_TURN":
-                    Message.showMessage("Turn started.");
+                    // Re-Enable the buttons for the player
                     StartTurnCommand startTurnCommand = gson.fromJson(message, StartTurnCommand.class);
+
                     int turnNumber = startTurnCommand.getDialogueTurn().getTurnNumber();
                     String dialog_msg = startTurnCommand.getDialogueTurn().getDungeonMasterText();
 
                     Dialog dialogueTurn = new Dialog(dialog_msg, null, turnNumber);
                     dialogRepo.updateTurnHistory(dialogueTurn);
+
+                    gameRepo.gameStarted();
+                    gameRepo.serverFree();
+
+                    Message.showMessage("Turn " + startTurnCommand.getDialogueTurn().getTurnNumber());
                     break;
 
                 case "SHOW_PLAYER_ACTIONS":
@@ -111,7 +118,9 @@ public class DicerealmClient extends WebSocketClient {
                     break;
 
                 case "DIALOGUE_END_TURN":
-                    // Send whatever the player selected to the server
+                    EndTurnCommand endTurnCommand = gson.fromJson(message, EndTurnCommand.class);
+                    // Disable the buttons for the player
+                    gameRepo.serverNotFree();
                     Message.showMessage("Turn ended.");
                     break;
 

--- a/android/app/src/main/java/com/example/dicerealmandroid/game/GameDataSource.java
+++ b/android/app/src/main/java/com/example/dicerealmandroid/game/GameDataSource.java
@@ -13,6 +13,7 @@ import com.example.dicerealmandroid.game.dialog.DialogDataSource;
 public class GameDataSource {
     private static GameDataSource instance;
     private MutableLiveData<Boolean> isGameRunning = new MutableLiveData<>(false);
+    private final MutableLiveData<Boolean> isGameServerBusy = new MutableLiveData<>(false);
     private GameDataSource(){}
 
 
@@ -29,5 +30,18 @@ public class GameDataSource {
 
     public void gameStarted(){
         isGameRunning.postValue(true);
+    }
+
+    // Turn related methods
+    public LiveData<Boolean> isGameServerBusy(){
+        return isGameServerBusy;
+    }
+
+    public void gameServerNotFree(){
+        isGameServerBusy.postValue(true);
+    }
+
+    public void gameServerFree(){
+        isGameServerBusy.postValue(false);
     }
 }

--- a/android/app/src/main/java/com/example/dicerealmandroid/game/GameRepo.java
+++ b/android/app/src/main/java/com/example/dicerealmandroid/game/GameRepo.java
@@ -30,4 +30,18 @@ public class GameRepo {
     public void gameStarted(){
         gameDataSource.gameStarted();
     }
+
+
+    // Turn related methods
+    public LiveData<Boolean> isServerBusy(){
+        return gameDataSource.isGameServerBusy();
+    }
+
+    public void serverNotFree(){
+        gameDataSource.gameServerNotFree();
+    }
+
+    public void serverFree(){
+        gameDataSource.gameServerFree();
+    }
 }

--- a/android/app/src/main/java/com/example/dicerealmandroid/game/GameStateHolder.java
+++ b/android/app/src/main/java/com/example/dicerealmandroid/game/GameStateHolder.java
@@ -75,4 +75,8 @@ public class GameStateHolder extends ViewModel {
     }
 
 
+    // Turn related methods
+    public LiveData<Boolean> isServerBusy(){
+        return gameRepo.isServerBusy();
+    }
 }


### PR DESCRIPTION
- Fix bug where game crashes when a player clicks on an action/item when the server is busy in dialog by disabling actions/items when turn ends, only enabling when turn starts again
- Add indication when the dungeon master is thinking (server busy)
- Fix cases where the dialog screen is just empty even when the game start by now only navigating when the server is completely ready 

## Test
![image](https://github.com/user-attachments/assets/54167de3-51c1-418e-8253-f93ae10edf78)
