### PR TITLE
fix: send action skillcheck instead of player stats in dialogue turn action command

### DIFF
--- a/android/app/src/main/java/com/example/dicerealmandroid/game/dialog/DialogRepo.java
+++ b/android/app/src/main/java/com/example/dicerealmandroid/game/dialog/DialogRepo.java
@@ -54,10 +54,8 @@ public class DialogRepo {
     }
 
     public void sendPlayerAction(DungeonMasterResponse.PlayerAction action){
-        StatsMap playerStats = playerDataSource.getPlayer().getValue().getStats();
         int turn = dialogDataSource.subscribeLatestTurn().getValue().getTurnNumber();
-
-        DialogueTurnActionCommand dialogAction = new DialogueTurnActionCommand(turn, UUID.fromString(action.playerId), action.action, playerStats);
+        DialogueTurnActionCommand dialogAction = new DialogueTurnActionCommand(turn, UUID.fromString(action.playerId), action.action, action.skillCheck.toStatsMap());
         String message = gson.toJson(dialogAction);
         roomDataSource.sendMessageToServer(message);
     }

--- a/core/lib/src/main/java/com/dicerealm/core/dm/DungeonMasterResponse.java
+++ b/core/lib/src/main/java/com/dicerealm/core/dm/DungeonMasterResponse.java
@@ -1,5 +1,10 @@
 package com.dicerealm.core.dm;
 
+import java.util.Map;
+
+import com.dicerealm.core.entity.Stat;
+import com.dicerealm.core.entity.StatsMap;
+
 /**
  * Response from the Dungeon Master should be serialized to this class
  * This response should contain the displayText shown to the players in the room, and the action choices that each player can make
@@ -26,5 +31,16 @@ public class DungeonMasterResponse{
 			public int INTELLIGENCE;
 			public int WISDOM;
 			public int CHARISMA;
+
+			public StatsMap toStatsMap() {
+				return new StatsMap(Map.of(
+					Stat.STRENGTH, STRENGTH,
+					Stat.DEXTERITY, DEXTERITY,
+					Stat.CONSTITUTION, CONSTITUTION,
+					Stat.INTELLIGENCE, INTELLIGENCE,
+					Stat.WISDOM, WISDOM,
+					Stat.CHARISMA, CHARISMA
+				));
+			}
 		}
 }


### PR DESCRIPTION
- send action skillcheck instead of player stats in dialogue turn action command