### PR TITLE
Feat/android/general game logic

### DIFF
--- a/android/app/src/main/java/com/example/dicerealmandroid/DicerealmClient.java
+++ b/android/app/src/main/java/com/example/dicerealmandroid/DicerealmClient.java
@@ -177,6 +177,7 @@ public class DicerealmClient extends WebSocketClient {
                         if (combatEndTurnCommand.getCombatResult().getDamageLog() != null) {
                             damageLog = combatEndTurnCommand.getCombatResult().getDamageLog();
                         }
+
                         combatRepo.setLatestTurn("Turn " + combatEndTurnCommand.getTurnNumber() + "\n" + combatEndTurnCommand.getCombatResult().getHitLog() + "\n" + damageLog);
                         combatRepo.rotateCombatSequence();
                     }

--- a/android/app/src/main/java/com/example/dicerealmandroid/activity/CharacterScreen.java
+++ b/android/app/src/main/java/com/example/dicerealmandroid/activity/CharacterScreen.java
@@ -21,6 +21,8 @@ import com.dicerealm.core.entity.EntityClass;
 import com.dicerealm.core.entity.Race;
 import com.dicerealm.core.inventory.InventoryOf;
 import com.dicerealm.core.item.Item;
+import com.dicerealm.core.item.Potion;
+import com.dicerealm.core.item.Scroll;
 import com.dicerealm.core.room.RoomState;
 import com.dicerealm.core.skills.Skill;
 import com.example.dicerealmandroid.game.GameStateHolder;
@@ -34,6 +36,7 @@ import com.example.dicerealmandroid.room.RoomStateHolder;
 import com.example.dicerealmandroid.util.Loading;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 
@@ -58,6 +61,7 @@ public class CharacterScreen extends AppCompatActivity {
         // Access PlayerStateHolder
         playerSh = new ViewModelProvider(this).get(PlayerStateHolder.class);
         roomSh = new ViewModelProvider(this).get(RoomStateHolder.class);
+
         this.backToHome();
         this.setRoomCode();
 

--- a/android/app/src/main/java/com/example/dicerealmandroid/activity/CombatScreen.java
+++ b/android/app/src/main/java/com/example/dicerealmandroid/activity/CombatScreen.java
@@ -126,7 +126,7 @@ public class CombatScreen extends AppCompatActivity implements SelectListener {
         playerSh.getPlayer().observe(this, new Observer<Player>() {
             @Override
             public void onChanged(Player player) {
-                playerName.setText("You");
+                playerName.setText(player.getDisplayName() + "(you)");
                 yourHealth.setText(player.getHealth() + "/" + player.getStat(Stat.MAX_HEALTH));
 
                 playerInfo.setText("");

--- a/android/app/src/main/java/com/example/dicerealmandroid/activity/DialogScreen.java
+++ b/android/app/src/main/java/com/example/dicerealmandroid/activity/DialogScreen.java
@@ -26,12 +26,14 @@ import androidx.core.view.WindowInsetsCompat;
 import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModelProvider;
 
+import com.dicerealm.core.dialogue.SkillCheck;
 import com.dicerealm.core.entity.BodyPart;
 import com.dicerealm.core.entity.Entity;
 import com.dicerealm.core.entity.Stat;
 import com.dicerealm.core.entity.StatsMap;
 import com.dicerealm.core.item.EquippableItem;
 import com.dicerealm.core.item.Item;
+import com.dicerealm.core.locations.Location;
 import com.dicerealm.core.player.Player;
 import com.dicerealm.core.room.RoomState;
 import com.example.dicerealmandroid.game.dialog.Dialog;
@@ -46,6 +48,7 @@ import com.example.dicerealmandroid.room.RoomStateHolder;
 import com.example.dicerealmandroid.util.ScreenDimensions;
 import com.google.android.material.bottomsheet.BottomSheetDialog;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
+import com.google.android.material.textview.MaterialTextView;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
@@ -93,6 +96,30 @@ public class DialogScreen extends AppCompatActivity {
         this.displayPlayerDetails(itemInventoryView);
         this.openItemInventory(itemInventoryModal, itemInventoryView);
         this.trackGameServer(messageLayout, actionLayout, itemInventoryView);
+        this.trackLocation();
+        this.showActionResults();
+    }
+
+    private void showActionResults(){
+        dialogSh.subscribeDialogLatestActionResult().observe(this, new Observer<SkillCheck.ActionResultDetail>() {
+           @Override
+           public void onChanged(SkillCheck.ActionResultDetail actionResultDetail){
+               if(actionResultDetail == null) return;
+               
+               String actionResultsSummary = actionResultDetail.toString();
+           }
+        });
+    }
+
+    private void trackLocation(){
+        MaterialTextView locationText = findViewById(R.id.location);
+        locationText.setTextSize(10);
+        gameSh.subscribeCurrentLocation().observe(this, new Observer<Location>() {
+           @Override
+           public void onChanged(Location location){
+               locationText.setText(location.getDisplayName());
+            }
+        });
     }
 
     private void trackGameServer(LinearLayout messageLayout, LinearLayout actionLayout, View itemInventoryView){
@@ -253,10 +280,20 @@ public class DialogScreen extends AppCompatActivity {
                         turnContainer.setTag(id);
                         ownerView.setGravity(Gravity.END); // flush right
 
-                        if(playerId.orElse(null).equals(playerSh.getPlayerId())){
-                            ownerView.setText("You");
-                        }else{
-                            ownerView.setText("Other player");
+                        Player[] players = roomSh.getAllPlayers();
+                        Player player1 = playerSh.getPlayer().getValue();
+
+                        // Show all players name for their respective action
+                        for(Player player: players){
+                            if(playerId.orElse(null).equals(player.getId())){
+                                
+                                // Check if player is you
+                                if(playerId.orElse(null).equals(playerSh.getPlayerId())){
+                                    ownerView.setText("You");
+                                }else{
+                                    ownerView.setText(player.getDisplayName());
+                                }
+                            }
                         }
                     }
 

--- a/android/app/src/main/java/com/example/dicerealmandroid/activity/DialogScreen.java
+++ b/android/app/src/main/java/com/example/dicerealmandroid/activity/DialogScreen.java
@@ -33,6 +33,8 @@ import com.dicerealm.core.entity.Stat;
 import com.dicerealm.core.entity.StatsMap;
 import com.dicerealm.core.item.EquippableItem;
 import com.dicerealm.core.item.Item;
+import com.dicerealm.core.item.Potion;
+import com.dicerealm.core.item.Scroll;
 import com.dicerealm.core.locations.Location;
 import com.dicerealm.core.player.Player;
 import com.dicerealm.core.room.RoomState;
@@ -91,6 +93,24 @@ public class DialogScreen extends AppCompatActivity {
         playerSh = new ViewModelProvider(this).get(PlayerStateHolder.class);
         roomSh = new ViewModelProvider(this).get(RoomStateHolder.class);
         dialogSh = new ViewModelProvider(this).get(DialogStateHolder.class);
+
+        playerSh.getSpecificInventoryType(Scroll.class).observe(this, scrolls -> {
+            if (scrolls != null) {
+                // Use scrolls list here
+                for(Scroll scroll : scrolls){
+                    Log.d("Scrolls", "You have the following scroll: " + scroll.getDisplayName());
+                }
+            }
+        });
+
+        playerSh.getSpecificInventoryType(Potion.class).observe(this, potions -> {
+            if (potions != null) {
+                // Use potions list here
+                for(Potion potion : potions) {
+                    Log.d("Potions", "You have the following potion: " + potion.getDisplayName());
+                }
+            }
+        });
 
         this.trackTurns(messageLayout, actionLayout);
         this.displayPlayerDetails(itemInventoryView);

--- a/android/app/src/main/java/com/example/dicerealmandroid/game/combat/CombatRepo.java
+++ b/android/app/src/main/java/com/example/dicerealmandroid/game/combat/CombatRepo.java
@@ -108,6 +108,8 @@ public class CombatRepo {
                 throw new IllegalArgumentException("Player cannot be null");
             }
             targetEntity.takeDamage(damage);
+            if (!targetEntity.isAlive()) removeCombatant(targetEntity.getId().toString());
+
             playerDataSource.setPlayer((Player) targetEntity);
         }
         else if (enemyId.equals(targetId)){

--- a/android/app/src/main/java/com/example/dicerealmandroid/game/combat/CombatRepo.java
+++ b/android/app/src/main/java/com/example/dicerealmandroid/game/combat/CombatRepo.java
@@ -91,15 +91,22 @@ public class CombatRepo {
     }
 
 
-    public void takeDamage(UUID targetId, int damage){
+    public void takeDamage(UUID targetId, int damage) throws IllegalArgumentException{
         UUID playerId = playerDataSource.getPlayerId();
-        UUID enemyId = getMonster().getValue().getId();
+        Entity enemy = getMonster().getValue();
+        if(enemy == null){
+            throw new IllegalArgumentException("There doesn't exist a monster");
+        }
+        UUID enemyId = enemy.getId();
 
         Entity targetEntity;
 
         // If target is the player (you) or enemy
         if (playerId.equals(targetId)){
             targetEntity = playerDataSource.getPlayer().getValue();
+            if(targetEntity == null){
+                throw new IllegalArgumentException("Player cannot be null");
+            }
             targetEntity.takeDamage(damage);
             playerDataSource.setPlayer((Player) targetEntity);
         }
@@ -108,6 +115,24 @@ public class CombatRepo {
             targetEntity.takeDamage(damage);
             combatDataSource.setMonster(targetEntity);
         }
+    }
+
+
+    // Remove combatant from the initiative list, maintaining the order
+    public void removeCombatant(String targetId){
+        UUID combatant = UUID.fromString(targetId);
+        List<InitiativeResult> initiativeResults =this.getInitiativeResults().getValue();
+        if(initiativeResults == null || initiativeResults.isEmpty()){
+            return;
+        }
+
+        for(int i =0; i < initiativeResults.size(); i++){
+            if(initiativeResults.get(i).getEntity().getId().equals(combatant)){
+                initiativeResults.remove(i);
+                break;
+            }
+        }
+        combatDataSource.setInitiativeResults(initiativeResults);
     }
 
 }

--- a/android/app/src/main/java/com/example/dicerealmandroid/game/dialog/Dialog.java
+++ b/android/app/src/main/java/com/example/dicerealmandroid/game/dialog/Dialog.java
@@ -25,4 +25,14 @@ public class Dialog {
     public int getTurnNumber() {
         return turnNumber;
     }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+    public void setSender(Optional<UUID> sender) {
+        this.sender = sender;
+    }
+    public void setTurnNumber(int turnNumber) {
+        this.turnNumber = turnNumber;
+    }
 }

--- a/android/app/src/main/java/com/example/dicerealmandroid/game/dialog/DialogStateHolder.java
+++ b/android/app/src/main/java/com/example/dicerealmandroid/game/dialog/DialogStateHolder.java
@@ -12,7 +12,6 @@ import java.util.List;
 public class DialogStateHolder extends ViewModel {
     private final DialogRepo dialogRepo;
 
-
     public DialogStateHolder() {
         // Constructor
         dialogRepo = new DialogRepo();

--- a/android/app/src/main/java/com/example/dicerealmandroid/player/PlayerRepo.java
+++ b/android/app/src/main/java/com/example/dicerealmandroid/player/PlayerRepo.java
@@ -13,6 +13,7 @@ import com.dicerealm.core.inventory.InventoryOf;
 import com.dicerealm.core.item.EquippableItem;
 import com.dicerealm.core.item.Item;
 import com.dicerealm.core.player.Player;
+import com.dicerealm.core.room.RoomState;
 import com.dicerealm.core.skills.Skill;
 import com.example.dicerealmandroid.room.RoomDataSource;
 import com.example.dicerealmandroid.room.RoomRepo;

--- a/android/app/src/main/java/com/example/dicerealmandroid/player/PlayerStateHolder.java
+++ b/android/app/src/main/java/com/example/dicerealmandroid/player/PlayerStateHolder.java
@@ -3,6 +3,7 @@ package com.example.dicerealmandroid.player;
 import android.util.Log;
 
 import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.Transformations;
 import androidx.lifecycle.ViewModel;
 
@@ -17,6 +18,7 @@ import com.dicerealm.core.item.Item;
 import com.dicerealm.core.player.Player;
 import com.dicerealm.core.skills.Skill;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
@@ -64,5 +66,19 @@ public class PlayerStateHolder extends ViewModel{
 
     public LiveData<InventoryOf<Item>> getScrolls_Potions(){
        return Transformations.map(playerRepo.getPlayer(), Entity::getInventory);
+    }
+
+    // Use this to get the specific inventory class you want (e.g. EquippableItems, Scrolls, Potions, etc)
+    // Skills is in a seperate inventory
+    public <T extends Item> LiveData<List<T>> getSpecificInventoryType(Class<T> itemClass){
+        return Transformations.map(playerRepo.getPlayer(), player -> {
+           List<T> specificInventory = new ArrayList<>();
+           for(Item item : player.getInventory().getItems()){
+               if(itemClass.isInstance(item)){
+                   specificInventory.add(itemClass.cast(item));
+               }
+           }
+           return specificInventory;
+        });
     }
 }

--- a/android/app/src/main/java/com/example/dicerealmandroid/room/RoomRepo.java
+++ b/android/app/src/main/java/com/example/dicerealmandroid/room/RoomRepo.java
@@ -59,6 +59,15 @@ public class RoomRepo {
         roomDataSource.setRoomState(roomState);
     }
 
+    public void updatePlayersList(Player player){
+        // Update the roomState Players List
+        RoomState roomState = roomDataSource.getRoomState().getValue();
+        if(roomState == null) return;
+        roomState.removePlayer(player.getId());
+        roomState.addPlayer(player);
+        roomDataSource.setRoomState(roomState);
+    }
+
     public void changeState(RoomState.State state){
         roomDataSource.changeState(state);
     }

--- a/android/app/src/main/res/layout/activity_dialog_screen.xml
+++ b/android/app/src/main/res/layout/activity_dialog_screen.xml
@@ -42,9 +42,18 @@
             android:gravity="center"
             android:layout_weight="1"/>
 
-        <View
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/location"
             android:layout_width="0dp"
-            android:layout_height="0dp"
+            android:layout_height="wrap_content"
+            android:textColor="@color/white"
+            android:text="location"
+            android:textStyle="bold"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            android:textAlignment="center"
+            android:gravity="center"
             android:layout_weight="1"/>
 
     </LinearLayout>


### PR DESCRIPTION
- Add location in `DialogScreen`
- Add displaying of specific player names in `DialogScreen`
- Add method that filters out specific item classes in `InventoryOf<Item>`
- Fix bug where combat sequence doesnt correlate to the server when a player leave/dies in `CombatScreen`
- Fix bug where in a multiplayer combat the player doesnt navigate back to the home page when he dies in `CombatScreen`
- Fix bug where `RoomState` players list doesnt show the updated player details
- Minor alteration of `CombatScreen` design




![image](https://github.com/user-attachments/assets/a04927b2-9d99-434b-a9da-eb0801194455)
